### PR TITLE
Add entry for Montlake network security demo example

### DIFF
--- a/directory.yaml
+++ b/directory.yaml
@@ -75,3 +75,5 @@
 - {repository: "https://github.com/brooklyncentral/brooklyn-nexus", branch: "master", file: "catalog/nexus/nexus.bom", parentId: "nexus-3"}
 - {repository: "https://github.com/brooklyncentral/brooklyn-jenkins", file: "catalog/jenkins/jenkins.bom", parentId: "jenkins"}
 - {repository: "https://github.com/brooklyncentral/brooklyn-alfresco", file: "catalog/alfresco/alfresco.bom", parentId: "alfresco"} 
+- {repository: "https://github.com/Montlake/blueprint-illustrations", file: "three-tier-nodejs-amp/amp-catalog.bom"}
+


### PR DESCRIPTION
This adds an entry for the blueprint put together to illustrate the use of Cloudsoft AMP's network security, as demonstrated by the videos in the Cloudsoft Youtube channel [Montlake Demos](https://www.youtube.com/playlist?list=PLgDS7QcqqEubXQWxdaqURNIuZcNqocLbY) playlist.